### PR TITLE
Fix View conditional modifier and rename string whitespace helper

### DIFF
--- a/Sources/UtilityKit/Extensions/StringProtocol+Extension.swift
+++ b/Sources/UtilityKit/Extensions/StringProtocol+Extension.swift
@@ -6,9 +6,17 @@
 //
 
 extension StringProtocol where Self: RangeReplaceableCollection {
-    
-    public var removeWhitespaceAndNewLines: Self {
+
+    /// 空白および改行文字を取り除いた新しい文字列を返します。
+    /// 元の文字列は変更されません。
+    public var removingWhitespacesAndNewlines: Self {
         filter { !$0.isWhitespace && !$0.isNewline }
     }
-    
+
+    /// `removingWhitespacesAndNewlines` への後方互換用プロパティ。
+    @available(*, deprecated, renamed: "removingWhitespacesAndNewlines")
+    public var removeWhitespaceAndNewLines: Self {
+        removingWhitespacesAndNewlines
+    }
+
 }

--- a/Sources/UtilityKit/Extensions/View+Extension.swift
+++ b/Sources/UtilityKit/Extensions/View+Extension.swift
@@ -9,10 +9,19 @@ public import SwiftUI
 
 @available(iOS 13.0, *)
 extension View {
-    
+
+    /// 条件が `true` の場合に指定した変換を適用します。
+    /// - Parameters:
+    ///   - condition: 変換を適用するかどうかの判定。
+    ///   - transform: 条件が成立した場合に適用するビュー変換。
+    /// - Returns: `condition` が `true` の場合は変換後のビュー、それ以外は元のビュー。
     @ViewBuilder
-    public func `if`<Content: View>(@ViewBuilder _ content: (Self) -> Content) -> some View {
-        content(self)
+    public func `if`<Content: View>(_ condition: Bool, @ViewBuilder transform: (Self) -> Content) -> some View {
+        if condition {
+            transform(self)
+        } else {
+            self
+        }
     }
-    
+
 }


### PR DESCRIPTION
## Summary
- fix `View.if` modifier to apply transform conditionally
- rename string whitespace helper to `removingWhitespacesAndNewlines` and add deprecation shim

## Testing
- `swift test` *(fails: no such module 'StoreKit')*

------
https://chatgpt.com/codex/tasks/task_e_68b97a8110c4833086dff70ed4b3b5a8