### PR TITLE
StringProtocol+Extension のフィルタ条件を簡素化

### DIFF
--- a/Sources/UtilityKit/Extensions/StringProtocol+Extension.swift
+++ b/Sources/UtilityKit/Extensions/StringProtocol+Extension.swift
@@ -10,7 +10,7 @@ extension StringProtocol where Self: RangeReplaceableCollection {
     /// 空白および改行文字を取り除いた新しい文字列を返します。
     /// 元の文字列は変更されません。
     public var removingWhitespacesAndNewlines: Self {
-        filter { !$0.isWhitespace && !$0.isNewline }
+        filter { !$0.isWhitespace }
     }
 
     /// `removingWhitespacesAndNewlines` への後方互換用プロパティ。


### PR DESCRIPTION
## 概要
- `removingWhitespacesAndNewlines` のフィルタを `isWhitespace` のみに変更

## テスト
- `swift test` (CoreData や SwiftUI が見つからず失敗)

------
https://chatgpt.com/codex/tasks/task_e_68b97c5e846883308f22713a1f2a6694