### PR TITLE
Guard SwiftUI and StoreKit code with conditional imports

### DIFF
--- a/Sources/ProductPurchaseKit/Product+Extension.swift
+++ b/Sources/ProductPurchaseKit/Product+Extension.swift
@@ -5,6 +5,7 @@
 //  Created by iwacchi on 2025/08/18.
 //
 
+#if canImport(StoreKit)
 import Foundation
 import StoreKit
 
@@ -190,3 +191,4 @@ extension Product.SubscriptionPeriod {
         return DateInterval(start: start, end: end)
     }
 }
+#endif

--- a/Sources/ProductPurchaseKit/ProductPurchaseExecutor.swift
+++ b/Sources/ProductPurchaseKit/ProductPurchaseExecutor.swift
@@ -5,6 +5,7 @@
 //  Created by iwacchi on 2025/08/18.
 //
 
+#if canImport(StoreKit)
 import Foundation
 import StoreKit
 
@@ -20,5 +21,6 @@ import StoreKit
     
     /// 権利の剥奪処理（返金/失効/ダウングレード時）
     func downgradeExecute() async
-    
+
 }
+#endif

--- a/Sources/ProductPurchaseKit/ProductPurchaseKit.swift
+++ b/Sources/ProductPurchaseKit/ProductPurchaseKit.swift
@@ -5,6 +5,7 @@
 //  Created by iwacchi on 2025/08/17.
 //
 
+#if canImport(StoreKit)
 import Foundation
 import StoreKit
 
@@ -164,7 +165,7 @@ public final class ProductPurchaseKit: @unchecked Sendable {
         try await AppStore.sync()
         let _ = await currentPurchasedTransaction()
     }
-    
+
     // MARK: - Observation
     /// `Transaction.updates` を監視開始
     /// - Parameters:
@@ -195,5 +196,6 @@ public final class ProductPurchaseKit: @unchecked Sendable {
             }
         }
     }
-    
+
 }
+#endif

--- a/Sources/UtilityKit/Appearance/AppearanceMode.swift
+++ b/Sources/UtilityKit/Appearance/AppearanceMode.swift
@@ -5,6 +5,7 @@
 //  Created by iwacchi on 2025/08/18.
 //
 
+#if canImport(SwiftUI)
 public import SwiftUI
 public import UIKit
 
@@ -69,3 +70,4 @@ public enum AppearanceMode: Int, CaseIterable, Codable, @unchecked Sendable {
     }
     
 }
+#endif

--- a/Sources/UtilityKit/Extensions/Color+Extension.swift
+++ b/Sources/UtilityKit/Extensions/Color+Extension.swift
@@ -5,6 +5,7 @@
 //  Created by iwacchi on 2025/08/17.
 //
 
+#if canImport(SwiftUI)
 public import Foundation
 public import SwiftUI
 public import UIKit
@@ -107,3 +108,4 @@ extension Color: Codable {
         }
     }
 }
+#endif

--- a/Sources/UtilityKit/Extensions/View+Extension.swift
+++ b/Sources/UtilityKit/Extensions/View+Extension.swift
@@ -5,6 +5,7 @@
 //  Created by iwacchi on 2025/08/18.
 //
 
+#if canImport(SwiftUI)
 public import SwiftUI
 
 @available(iOS 13.0, *)
@@ -25,3 +26,4 @@ extension View {
     }
 
 }
+#endif


### PR DESCRIPTION
## Summary
- SwiftUIに依存する拡張やユーティリティを`#if canImport(SwiftUI)`で囲み、`public import SwiftUI`を内部へ移動
- StoreKitに依存する購買ロジックを`#if canImport(StoreKit)`で条件コンパイル

## Testing
- `swift test` *(失敗: CoreData等のモジュールが存在しない)*

------
https://chatgpt.com/codex/tasks/task_e_68b97c59136c8330845b42a941ea90a3